### PR TITLE
[#97] Removed all mentions of the Z-SGOV vocabulary and its terms

### DIFF
--- a/src/api/TermAPI.ts
+++ b/src/api/TermAPI.ts
@@ -2,26 +2,38 @@ import { useQuery } from "react-query";
 import { firstValueFrom } from "rxjs";
 
 import { TermBaseInterface, Terms } from "./data/terms";
+import { HIDDEN_VOCABULARY } from "./data/vocabularies";
 
 // This is a supertype of TermBaseInterface containing term id and vocabulary id
 export type TermBase = Pick<TermBaseInterface, "$id"> & {
   vocabulary: Pick<TermBaseInterface["vocabulary"], "$id">;
 };
 
-export const getTerm = async (termIri: string) => {
-  const data = await firstValueFrom(Terms.findByIri(termIri));
+export const getTerm = async (term: TermBase) => {
+  //If user is trying to fetch term from hidden vocabulary, immediately return null -> no retries from React Query
+  if (term.vocabulary.$id === HIDDEN_VOCABULARY) return null;
+
+  const data = await firstValueFrom(Terms.findByIri(term.$id));
 
   if (!data) {
     // Term not found
     throw new Error("404 Term not found");
   }
 
+  //Removes all mentions of terms coming from hidden vocabulary
+  (data.parentTerms as TermBaseInterface[]) = data.parentTerms.filter(
+    (term) => term.vocabulary.$id !== HIDDEN_VOCABULARY
+  );
+  (data.subTerms as TermBaseInterface[]) = data.subTerms.filter(
+    (term) => term.vocabulary.$id !== HIDDEN_VOCABULARY
+  );
+
   return data;
 };
 
-export const useTerm = (termIri: string) => {
-  return useQuery(["term", termIri], () => getTerm(termIri), {
-    enabled: !!termIri,
+export const useTerm = (term: TermBase) => {
+  return useQuery(["term", term.$id], () => getTerm(term), {
+    enabled: !!term.$id,
     notifyOnChangeProps: ["data", "isError"],
   });
 };

--- a/src/api/VocabularyAPI.ts
+++ b/src/api/VocabularyAPI.ts
@@ -2,11 +2,15 @@ import { useQuery } from "react-query";
 import { firstValueFrom } from "rxjs";
 import {
   getVocabularyTermsQuery,
+  HIDDEN_VOCABULARY,
   Vocabularies,
   VocabularyTerms,
 } from "./data/vocabularies";
 
 export const getVocabulary = async (vocabularyIri: string) => {
+  //If user is trying to fetch hidden vocabulary, immediately return null -> no retries from React Query
+  if (vocabularyIri === HIDDEN_VOCABULARY) return null;
+
   const data = await firstValueFrom(Vocabularies.findByIri(vocabularyIri));
 
   if (!data) {
@@ -34,7 +38,6 @@ const getVocabularyTerms = async (vocabularyIri: string) => {
   );
 
   data.sort((a, b) => a.label.localeCompare(b.label));
-
   return data;
 };
 

--- a/src/api/data/search.ts
+++ b/src/api/data/search.ts
@@ -4,6 +4,7 @@ import { namedNode as n, literal as l } from "@ldkit/rdf";
 import { $ } from "@ldkit/sparql";
 import { lucene, luceneInstance, popisDat } from "./namespaces";
 import { context } from "./context";
+import { HIDDEN_VOCABULARY } from "./vocabularies";
 
 const VocabularySchema = {
   "@type": popisDat["slovník"],
@@ -105,6 +106,7 @@ CONSTRUCT {
     _:s ${n(lucene.snippetText)} ?snippetText ;
         ${n(lucene.snippetField)} ?snippetField .
     FILTER (lang(?label) = "cs")
+    FILTER (?vocabulary != ${n(HIDDEN_VOCABULARY)})
     BIND(IF(lcase(str(?snippetText)) = lcase(str(${l(
       exactMatchString
     )})), ?initScore * 2, IF(CONTAINS(lcase(str(?snippetText)), ${l(
@@ -156,6 +158,7 @@ CONSTRUCT {
     _:s ${n(lucene.snippetText)} ?snippetText ;
         ${n(lucene.snippetField)} ?snippetField .
     FILTER (lang(?label) = "cs")
+    FILTER (?entity != ${n(HIDDEN_VOCABULARY)})
     BIND(IF(lcase(str(?snippetText)) = lcase(str(${l(
       exactMatchString
     )})), ?initScore * 2, IF(CONTAINS(lcase(str(?snippetText)), ${l(

--- a/src/api/data/vocabularies.ts
+++ b/src/api/data/vocabularies.ts
@@ -7,6 +7,8 @@ import { context } from "./context";
 import { popisDat } from "./namespaces";
 import { TermBaseSchema } from "./terms";
 
+export const HIDDEN_VOCABULARY = "https://slovník.gov.cz/základní";
+
 const VocabularyTermSchema = {
   "@type": TermBaseSchema["@type"],
   label: TermBaseSchema.label,

--- a/src/components/TermPage.tsx
+++ b/src/components/TermPage.tsx
@@ -13,7 +13,7 @@ import { isTermEmpty } from "../utils/TermUtils";
 
 const TermPage: React.FC = () => {
   const term = useURLTerm();
-  const { data, isLoading, isSuccess, isError } = useTerm(term.$id);
+  const { data, isLoading, isSuccess, isError } = useTerm(term);
 
   if (isLoading) return <Loader />;
 


### PR DESCRIPTION
Vocabulary and terms from the Z-SGOV are no longer searchable in the app. They are not being shown in the term hierarchy and it is also not possible to find vocabulary nor terms by looking for specific URL.

Resolves #97 