### PR TITLE
Feature/111 lucene query fix

### DIFF
--- a/src/api/WordsAPI.ts
+++ b/src/api/WordsAPI.ts
@@ -13,6 +13,8 @@ const getSearchResults = async (word: string | undefined) => {
   if (!word) {
     return [];
   }
+  word = word.replace(/(?=[()/])/g, "\\");
+
   const data = await firstValueFrom(SearchResource.query(getSearchQuery(word)));
   const vocabularyData = await firstValueFrom(
     VocabularySearchResource.query(getVocabularySearchQuery(word))
@@ -84,8 +86,6 @@ export const useSearch = (word: string | undefined) => {
   word = word?.replace(/[ /\t]+$/, "");
   //removes all leading whitespaces
   word = word?.replace(/^[ /\t]+/, "");
-  //escapes forward slashes, necessary for lucene query
-  word = word?.replace(/\//g, "\\/");
 
   return useQuery(["directsearch", word], () => getSearchResults(word), {
     enabled: !!word,

--- a/src/api/WordsAPI.ts
+++ b/src/api/WordsAPI.ts
@@ -80,6 +80,13 @@ export type SearchResult = ReturnType<typeof getSearchResults> extends Promise<
 export type SearchTerm = SearchResult["items"] extends (infer U)[] ? U : never;
 
 export const useSearch = (word: string | undefined) => {
+  //removes all trailing whitespaces
+  word = word?.replace(/[ /\t]+$/, "");
+  //removes all leading whitespaces
+  word = word?.replace(/^[ /\t]+/, "");
+  //escapes forward slashes, necessary for lucene query
+  word = word?.replace(/\//g, "\\/");
+
   return useQuery(["directsearch", word], () => getSearchResults(word), {
     enabled: !!word,
   });

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -17,6 +17,15 @@ const SearchPage: React.FC = () => {
 
   if (isLoading) return <Loader />;
 
+  if (isError) {
+    return (
+      <Box>
+        <LargeSearchBar searchedText={""} />
+        <NoResults />
+      </Box>
+    );
+  }
+
   return (
     <Box>
       <LargeSearchBar searchedText={wordLabel} />
@@ -24,7 +33,7 @@ const SearchPage: React.FC = () => {
       <Container>
         <Box pt={2} pb={4}>
           <NumberOfResults amount={data.length > 50 ? 50 : data.length} />
-          {data.length && !isError ? (
+          {data.length ? (
             data.slice(0, NUMBER_OF_RESULT).map((item) => {
               return <SearchResultView key={item.label} {...item} />;
             })
@@ -36,5 +45,4 @@ const SearchPage: React.FC = () => {
     </Box>
   );
 };
-
 export default SearchPage;

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -17,7 +17,6 @@ const SearchPage: React.FC = () => {
 
   if (isLoading) return <Loader />;
 
-  if (isError) return <Typography variant="h1">Error occurred</Typography>;
   return (
     <Box>
       <LargeSearchBar searchedText={wordLabel} />
@@ -25,7 +24,7 @@ const SearchPage: React.FC = () => {
       <Container>
         <Box pt={2} pb={4}>
           <NumberOfResults amount={data.length > 50 ? 50 : data.length} />
-          {data.length ? (
+          {data.length && !isError ? (
             data.slice(0, NUMBER_OF_RESULT).map((item) => {
               return <SearchResultView key={item.label} {...item} />;
             })

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container } from "@mui/material";
 import { useSearch } from "../../api/WordsAPI";
 import useRouteQuery from "../../hooks/useRouteQuery";
 import SearchResultView from "./SearchResult";


### PR DESCRIPTION
Lucene query doesn't allow certain characters in the query. Some of them appear in labels of vocabularies, which effectively caused the search to crash. Also I removed whitespaces before and after the search string. The results were super confused with them included in the search string. It was especially troublesome on mobile devices which add whitespace when selecting from keyboard autosuggestions.

Resolves: #111 