### PR TITLE
113/feature relations on mobile

### DIFF
--- a/src/components/terms/PropertyRelations.tsx
+++ b/src/components/terms/PropertyRelations.tsx
@@ -3,6 +3,8 @@ import { Box, styled } from "@mui/material";
 import { CurrentRelationTerm } from "./RelationItem";
 import TermRelations, { RelationsItemProps } from "./TermRelations";
 import { calculateConnector } from "./Relations";
+import useIsMobile from "../../hooks/useIsMobile";
+import PropertyRelationsMobile from "./PropertyRelationsMobile";
 
 const TermBox = styled(Box)(({ theme }) => ({
   flex: 3,
@@ -19,6 +21,7 @@ const PropertyRelations: React.FC<RelationsItemProps> = ({
   ranges,
   currentTerm,
 }) => {
+  const mobileActive = useIsMobile();
   if (domains.length === 0 || ranges.length === 0)
     return (
       <TermRelations
@@ -27,7 +30,15 @@ const PropertyRelations: React.FC<RelationsItemProps> = ({
         ranges={domains}
       />
     );
-
+  if (mobileActive) {
+    return (
+      <PropertyRelationsMobile
+        currentTerm={currentTerm}
+        domains={domains}
+        ranges={ranges}
+      />
+    );
+  }
   const firstRow =
     domains.length && ranges.length ? (
       <Box flex={1} display="flex" alignItems="center" justifyContent="center">

--- a/src/components/terms/PropertyRelations.tsx
+++ b/src/components/terms/PropertyRelations.tsx
@@ -22,7 +22,8 @@ const PropertyRelations: React.FC<RelationsItemProps> = ({
   currentTerm,
 }) => {
   const mobileActive = useIsMobile();
-  if (domains.length === 0 || ranges.length === 0)
+
+  if (domains.length === 0 || ranges.length === 0) {
     return (
       <TermRelations
         currentTerm={currentTerm}
@@ -30,6 +31,8 @@ const PropertyRelations: React.FC<RelationsItemProps> = ({
         ranges={domains}
       />
     );
+  }
+
   if (mobileActive) {
     return (
       <PropertyRelationsMobile
@@ -39,6 +42,7 @@ const PropertyRelations: React.FC<RelationsItemProps> = ({
       />
     );
   }
+
   const firstRow =
     domains.length && ranges.length ? (
       <Box flex={1} display="flex" alignItems="center" justifyContent="center">

--- a/src/components/terms/PropertyRelationsMobile.tsx
+++ b/src/components/terms/PropertyRelationsMobile.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from "react";
 import { RelationsItemProps } from "./TermRelations";
 import { Box } from "@mui/material";
 import { CurrentRelationTerm } from "./RelationItem";
-import { getRelationPosition } from "../../utils/TermUtils";
+import { getRelationPosition, RelationPosition } from "../../utils/TermUtils";
 import RelationItemWrapper, {
   RelationItemWrapperProps,
 } from "./RelationItemWrapperMobile";
@@ -38,6 +38,8 @@ const PropertyRelationsMobile: React.FC<RelationsItemProps> = ({
   );
 };
 
+//Code belows addresses all possible connectors for terms regarding their position in the visualisation
+
 const wrappedCurrent = (
   currElement: ReactElement
 ): RelationItemWrapperProps => {
@@ -52,10 +54,10 @@ const wrappedCurrent = (
 };
 
 const getDomainConnectors = (
-  position: string,
+  position: RelationPosition,
   currElement: ReactElement
 ): RelationItemWrapperProps => {
-  if (position === "ONLY_ONE") {
+  if (position === RelationPosition.ONLY_ONE) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_lline180"} />,
@@ -64,21 +66,21 @@ const getDomainConnectors = (
       row2L: <RelationConnector type={"m_lline270"} />,
     };
   }
-  if (position === "FIRST") {
+  if (position === RelationPosition.FIRST) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_lline180"} />,
       row2R: <RelationConnector type={"m_f_vertical"} />,
     };
   }
-  if (position === "MIDDLE" ) {
+  if (position === RelationPosition.MIDDLE) {
     return {
       row1L: <RelationConnector type={"m_hline"} />,
       row1M: currElement,
       row2L: <RelationConnector type={"m_vertical"} />,
     };
   }
-  if (position === "LAST") {
+  if (position === RelationPosition.LAST) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_f_hline"} />,
@@ -88,34 +90,37 @@ const getDomainConnectors = (
     };
   }
 
-  return {};
+  return { row1M: currElement };
 };
 
 const getRangeConnectors = (
-  position: string,
+  position: RelationPosition,
   currElement: ReactElement
 ): RelationItemWrapperProps => {
-  if (position === "ONLY_ONE") {
+  if (position === RelationPosition.ONLY_ONE) {
     return {
       row1L: <RelationConnector type={"m_lline"} />,
       row1M: currElement,
     };
   }
-  if (position === "MIDDLE" || position === "FIRST") {
+  if (
+    position === RelationPosition.MIDDLE ||
+    position === RelationPosition.FIRST
+  ) {
     return {
       row1M: currElement,
       row1L: <RelationConnector type={"m_hline"} />,
       row2L: <RelationConnector type={"m_vertical"} />,
     };
   }
-  if (position === "LAST") {
+  if (position === RelationPosition.LAST) {
     return {
       row1L: <RelationConnector type={"m_lline"} />,
       row1M: currElement,
     };
   }
 
-  return {};
+  return { row1M: currElement };
 };
 
 export default PropertyRelationsMobile;

--- a/src/components/terms/PropertyRelationsMobile.tsx
+++ b/src/components/terms/PropertyRelationsMobile.tsx
@@ -71,7 +71,7 @@ const getDomainConnectors = (
       row2R: <RelationConnector type={"m_f_vertical"} />,
     };
   }
-  if (position === "MIDDLE" || position === "PENULTIMATE") {
+  if (position === "MIDDLE" ) {
     return {
       row1L: <RelationConnector type={"m_hline"} />,
       row1M: currElement,
@@ -101,11 +101,7 @@ const getRangeConnectors = (
       row1M: currElement,
     };
   }
-  if (
-    position === "MIDDLE" ||
-    position === "PENULTIMATE" ||
-    position === "FIRST"
-  ) {
+  if (position === "MIDDLE" || position === "FIRST") {
     return {
       row1M: currElement,
       row1L: <RelationConnector type={"m_hline"} />,

--- a/src/components/terms/PropertyRelationsMobile.tsx
+++ b/src/components/terms/PropertyRelationsMobile.tsx
@@ -1,0 +1,125 @@
+import React, { ReactElement } from "react";
+import { RelationsItemProps } from "./TermRelations";
+import { Box } from "@mui/material";
+import { CurrentRelationTerm } from "./RelationItem";
+import { getRelationPosition } from "../../utils/TermUtils";
+import RelationItemWrapper, {
+  RelationItemWrapperProps,
+} from "./RelationItemWrapperMobile";
+import RelationConnector from "./RelationConnector";
+
+const PropertyRelationsMobile: React.FC<RelationsItemProps> = ({
+  domains,
+  ranges,
+  currentTerm,
+}) => {
+  const domainRows = domains.map((item, index) => {
+    const position = getRelationPosition(index, domains.length);
+    const props = getDomainConnectors(position, item);
+    return <RelationItemWrapper key={item.key} {...props} />;
+  });
+
+  const rangeRows = ranges.map((item, index) => {
+    const position = getRelationPosition(index, ranges.length);
+    const props = getRangeConnectors(position, item);
+    return <RelationItemWrapper key={item.key} {...props} />;
+  });
+
+  const currEl = (
+    <CurrentRelationTerm key={currentTerm.$id} data={currentTerm} />
+  );
+
+  return (
+    <Box mt={1}>
+      {domains.length !== 0 && domainRows}
+      <RelationItemWrapper key={currEl.key} {...wrappedCurrent(currEl)} />
+      {ranges.length !== 0 && rangeRows}
+    </Box>
+  );
+};
+
+const wrappedCurrent = (
+  currElement: ReactElement
+): RelationItemWrapperProps => {
+  return {
+    row1M: currElement,
+    row1L: <RelationConnector type={"m_lline"} />,
+    row1R: <RelationConnector type={"m_lline180"} />,
+    row2M: <RelationConnector type={"m_horizontal"} />,
+    row2R: <RelationConnector type={"m_f_lline"} />,
+    row2L: <RelationConnector type={"m_lline270"} />,
+  };
+};
+
+const getDomainConnectors = (
+  position: string,
+  currElement: ReactElement
+): RelationItemWrapperProps => {
+  if (position === "ONLY_ONE") {
+    return {
+      row1M: currElement,
+      row1R: <RelationConnector type={"m_lline180"} />,
+      row2R: <RelationConnector type={"m_f_lline"} />,
+      row2M: <RelationConnector type={"m_horizontal"} />,
+      row2L: <RelationConnector type={"m_lline270"} />,
+    };
+  }
+  if (position === "FIRST") {
+    return {
+      row1M: currElement,
+      row1R: <RelationConnector type={"m_lline180"} />,
+      row2R: <RelationConnector type={"m_f_vertical"} />,
+    };
+  }
+  if (position === "MIDDLE" || position === "PENULTIMATE") {
+    return {
+      row1L: <RelationConnector type={"m_hline"} />,
+      row1M: currElement,
+      row2L: <RelationConnector type={"m_vertical"} />,
+    };
+  }
+  if (position === "LAST") {
+    return {
+      row1M: currElement,
+      row1R: <RelationConnector type={"m_f_hline"} />,
+      row2R: <RelationConnector type={"m_f_lline"} />,
+      row2M: <RelationConnector type={"m_horizontal"} />,
+      row2L: <RelationConnector type={"m_lline270"} />,
+    };
+  }
+
+  return {};
+};
+
+const getRangeConnectors = (
+  position: string,
+  currElement: ReactElement
+): RelationItemWrapperProps => {
+  if (position === "ONLY_ONE") {
+    return {
+      row1L: <RelationConnector type={"m_lline"} />,
+      row1M: currElement,
+    };
+  }
+  if (
+    position === "MIDDLE" ||
+    position === "PENULTIMATE" ||
+    position === "FIRST"
+  ) {
+    return {
+      row1M: currElement,
+      row1L: <RelationConnector type={"m_hline"} />,
+      row2L: <RelationConnector type={"m_vertical"} />,
+    };
+  }
+  if (position === "LAST") {
+    return {
+      row1L: <RelationConnector type={"m_lline"} />,
+      row1M: currElement,
+    };
+  }
+
+  return {};
+};
+
+export default PropertyRelationsMobile;

--- a/src/components/terms/RelationConnector.tsx
+++ b/src/components/terms/RelationConnector.tsx
@@ -194,12 +194,12 @@ export const MobileLLine270: React.FC = () => {
 };
 
 export const MobileFlippedLLine: React.FC = () => {
-    return (
-        <Box flex={1}>
-            <ConnectorBox flex={1} style={{ borderWidth: "0px 4px 2px 0px" }} />
-            <ConnectorBox flex={1} style={{ borderWidth: "2px 0px 0px 0px" }} />
-        </Box>
-    );
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 4px 2px 0px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "2px 0px 0px 0px" }} />
+    </Box>
+  );
 };
 
 export const MobileFlippedLLine90: React.FC = () => {
@@ -238,7 +238,6 @@ export const MobileFlippedHLine: React.FC = () => {
   );
 };
 
-//Straight shifted
 export const MobileHorizontal: React.FC = () => {
   return (
     <Box flex={1}>

--- a/src/components/terms/RelationConnector.tsx
+++ b/src/components/terms/RelationConnector.tsx
@@ -21,6 +21,18 @@ const RelationConnector: React.FC<RelationConnectorProps> = ({ type }) => {
   else if (type === "r_hline") connector = <ReverseHLine />;
   else if (type === "r_lline") connector = <ReverseLLine />;
   else if (type === "r_tline") connector = <ReverseTLine />;
+  else if (type === "m_hline") connector = <MobileHLine />;
+  else if (type === "m_f_hline") connector = <MobileFlippedHLine />;
+  else if (type === "m_lline") connector = <MobileLLine />;
+  else if (type === "m_lline90") connector = <MobileLLine90 />;
+  else if (type === "m_lline180") connector = <MobileLLine180 />;
+  else if (type === "m_lline270") connector = <MobileLLine270 />;
+  else if (type === "m_f_lline") connector = <MobileFlippedLLine />;
+  else if (type === "m_f_lline90") connector = <MobileFlippedLLine90 />;
+  else if (type === "m_f_lline180") connector = <MobileFlippedLLine180 />;
+  else if (type === "m_horizontal") connector = <MobileHorizontal />;
+  else if (type === "m_vertical") connector = <MobileVertical />;
+  else if (type === "m_f_vertical") connector = <MobileFlippedVertical />;
   else return null;
 
   return (
@@ -30,6 +42,7 @@ const RelationConnector: React.FC<RelationConnectorProps> = ({ type }) => {
   );
 };
 
+//For desktop view only
 export const StraightLine: React.FC = () => {
   return (
     <>
@@ -139,6 +152,117 @@ export const ReverseLLine: React.FC = () => {
         <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 0px 0px" }} />
       </Box>
     </>
+  );
+};
+
+//For mobile only
+
+export const MobileLLine: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 0px 4px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "4px 0px 0px 0px" }} />
+    </Box>
+  );
+};
+
+export const MobileLLine90: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 4px 2px 0px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "2px 0px 0px 0px" }} />
+    </Box>
+  );
+};
+
+export const MobileLLine180: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 2px 0px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "2px 4px 0px 0px" }} />
+    </Box>
+  );
+};
+
+export const MobileLLine270: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 2px 0px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "2px 0px 0px 4px" }} />
+    </Box>
+  );
+};
+
+export const MobileFlippedLLine: React.FC = () => {
+    return (
+        <Box flex={1}>
+            <ConnectorBox flex={1} style={{ borderWidth: "0px 4px 2px 0px" }} />
+            <ConnectorBox flex={1} style={{ borderWidth: "2px 0px 0px 0px" }} />
+        </Box>
+    );
+};
+
+export const MobileFlippedLLine90: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 2px 4px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "2px 0px 0px 0px" }} />
+    </Box>
+  );
+};
+
+export const MobileFlippedLLine180: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 4px 0px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 0px 4px" }} />
+    </Box>
+  );
+};
+
+export const MobileHLine: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 0px 0px 4px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "4px 0px 0px 4px" }} />
+    </Box>
+  );
+};
+
+export const MobileFlippedHLine: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox flex={1} style={{ borderWidth: "0px 4px 0px 0px" }} />
+      <ConnectorBox flex={1} style={{ borderWidth: "4px 4px 0px 0px" }} />
+    </Box>
+  );
+};
+
+//Straight shifted
+export const MobileHorizontal: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox style={{ borderWidth: "0px 0px 2px 0px" }} />
+      <ConnectorBox style={{ borderWidth: "2px 0px 0px 0px" }} />
+    </Box>
+  );
+};
+
+export const MobileVertical: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox style={{ borderWidth: "0px 0px 0px 4px" }} />
+      <ConnectorBox style={{ borderWidth: "0px 0px 0px 4px" }} />
+    </Box>
+  );
+};
+
+export const MobileFlippedVertical: React.FC = () => {
+  return (
+    <Box flex={1}>
+      <ConnectorBox style={{ borderWidth: "0px 4px 0px 0px" }} />
+      <ConnectorBox style={{ borderWidth: "0px 4px 0px 0px" }} />
+    </Box>
   );
 };
 

--- a/src/components/terms/RelationConnector.tsx
+++ b/src/components/terms/RelationConnector.tsx
@@ -9,9 +9,23 @@ const ConnectorBox = styled(Box)({
 });
 
 interface RelationConnectorProps {
-  type?: string;
+  type: string;
 }
 
+//Wrapper component for all possible connectors
+/**Types:
+ *  straight
+ *  lline( resembles L shape)
+ *  hline (resembles H shape)
+ *  tline (resembles T shape)
+ *  vertical
+ *  horizontal (same as straight, just for mobile)
+ *  Modifiers:
+ *  r_ reversed direction
+ *  m_ mobile version
+ *  f_ mirrored
+ *  m_line{number} number indicates angle of ccw rotation
+ * **/
 const RelationConnector: React.FC<RelationConnectorProps> = ({ type }) => {
   let connector;
   if (type === "straight") connector = <StraightLine />;
@@ -155,8 +169,7 @@ export const ReverseLLine: React.FC = () => {
   );
 };
 
-//For mobile only
-
+//For mobile view only
 export const MobileLLine: React.FC = () => {
   return (
     <Box flex={1}>

--- a/src/components/terms/RelationItemWrapperMobile.tsx
+++ b/src/components/terms/RelationItemWrapperMobile.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement } from "react";
+import { Box, BoxProps } from "@mui/material";
+
+export interface RelationItemWrapperProps {
+  row1L?: ReactElement;
+  row1M?: ReactElement;
+  row1R?: ReactElement;
+  row2L?: ReactElement;
+  row2M?: ReactElement;
+  row2R?: ReactElement;
+  boxProps?: BoxProps;
+}
+
+const RelationItemWrapper: React.FC<RelationItemWrapperProps> = ({
+  row1L,
+  row1M,
+  row1R,
+  row2L,
+  row2M,
+  row2R,
+  boxProps,
+}) => {
+  return (
+    <Box display="flex" width="100%" flexDirection="column" {...boxProps}>
+      {/**Top row**/}
+      <Box flex={1} display={"flex"}>
+        <Box flex={1} maxWidth={16}>
+          {row1L}
+        </Box>
+        <Box
+          flex={10}
+          display={"flex"}
+          justifyContent={"center"}
+          alignItems={"center"}
+        >
+          {row1M}
+        </Box>
+        <Box flex={1} maxWidth={16}>
+          {row1R}
+        </Box>
+      </Box>
+
+      {/**Bottom row**/}
+      <Box flex={1} display={"flex"} minHeight={16}>
+        <Box flex={1} maxWidth={16}>
+          {row2L}
+        </Box>
+        <Box flex={10}>{row2M}</Box>
+        <Box flex={1} maxWidth={16}>
+          {row2R}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default RelationItemWrapper;

--- a/src/components/terms/TermRelations.tsx
+++ b/src/components/terms/TermRelations.tsx
@@ -27,6 +27,18 @@ const TermRelations: React.FC<RelationsItemProps> = ({
   currentTerm,
   ranges,
 }) => {
+  const mobileActive = useIsMobile();
+
+  if (mobileActive) {
+    return (
+      <TermRelationsMobile
+        currentTerm={currentTerm}
+        domains={domains}
+        ranges={ranges}
+      />
+    );
+  }
+
   const domainRows = domains.map((item, index) => {
     return (
       <Box display="flex" key={item.key}>
@@ -51,23 +63,12 @@ const TermRelations: React.FC<RelationsItemProps> = ({
     );
   });
 
-  const mobileActive = useIsMobile();
-  if (!mobileActive) {
-    return (
-      <Box mt={1}>
-        {domains.length !== 0 && domainRows}
-        {ranges.length !== 0 && rangeRows}
-      </Box>
-    );
-  } else {
-    return (
-      <TermRelationsMobile
-        currentTerm={currentTerm}
-        domains={domains}
-        ranges={ranges}
-      />
-    );
-  }
+  return (
+    <Box mt={1}>
+      {domains.length !== 0 && domainRows}
+      {ranges.length !== 0 && rangeRows}
+    </Box>
+  );
 };
 
 export default TermRelations;

--- a/src/components/terms/TermRelations.tsx
+++ b/src/components/terms/TermRelations.tsx
@@ -1,8 +1,11 @@
 import React, { ReactElement } from "react";
-import { Box, styled } from "@mui/material";
+import { Box, styled, Typography } from "@mui/material";
 import { TermInterface } from "../../api/data/terms";
 import { CurrentRelationTerm } from "./RelationItem";
 import { calculateConnector } from "./Relations";
+import RelationConnector, { TLine } from "./RelationConnector";
+import useIsMobile from "../../hooks/useIsMobile";
+import TermRelationsMobile from "./TermRelationsMobile";
 
 export interface RelationsItemProps {
   currentTerm: TermInterface;
@@ -26,55 +29,41 @@ const TermRelations: React.FC<RelationsItemProps> = ({
   ranges,
 }) => {
   const domainRows = domains.map((item, index) => {
-    if (index === 0) {
-      return (
-        <Box display="flex" key={item.key}>
-          <TermBox>
-            <CurrentRelationTerm data={currentTerm} />
-          </TermBox>
-          <Box flex={1}>{calculateConnector(index, domains.length, false)}</Box>
-          <TermBox>{item}</TermBox>
-        </Box>
-      );
-    } else {
-      return (
-        <Box display="flex" key={item.key}>
-          <TermBox />
-          <Box flex={1}>{calculateConnector(index, domains.length, false)}</Box>
-          <TermBox>{item}</TermBox>
-        </Box>
-      );
-    }
+    return (
+      <Box display="flex" key={item.key}>
+        <TermBox>
+          {index === 0 && <CurrentRelationTerm data={currentTerm} />}
+        </TermBox>
+        <Box flex={1}>{calculateConnector(index, domains.length, false)}</Box>
+        <TermBox>{item}</TermBox>
+      </Box>
+    );
   });
 
   const rangeRows = ranges.map((item, index) => {
-    if (index === 0) {
-      return (
-        <Box display="flex" key={item.key}>
-          <TermBox>{item}</TermBox>
-          <Box flex={1}>{calculateConnector(index, ranges.length, true)}</Box>
-          <TermBox>
-            <CurrentRelationTerm data={currentTerm} />
-          </TermBox>
-        </Box>
-      );
-    } else {
-      return (
-        <Box display="flex" key={item.key}>
-          <TermBox>{item}</TermBox>
-          <Box flex={1}>{calculateConnector(index, ranges.length, true)}</Box>
-          <TermBox />
-        </Box>
-      );
-    }
+    return (
+      <Box display="flex" key={item.key}>
+        <TermBox>{item}</TermBox>
+        <Box flex={1}>{calculateConnector(index, ranges.length, true)}</Box>
+        <TermBox>
+          {index === 0 && <CurrentRelationTerm data={currentTerm} />}
+        </TermBox>
+      </Box>
+    );
   });
 
-  return (
-    <Box mt={1}>
-      {domains.length !== 0 && domainRows}
-      {ranges.length !== 0 && rangeRows}
-    </Box>
-  );
+  const mobileActive = useIsMobile();
+  if (!mobileActive) {
+    return (
+      <Box mt={1}>
+        {domains.length !== 0 && domainRows}
+        {ranges.length !== 0 && rangeRows}
+      </Box>
+    );
+  } else {
+    return <TermRelationsMobile currentTerm={currentTerm} domains={domains} ranges={ranges}/>
+  }
 };
+
 
 export default TermRelations;

--- a/src/components/terms/TermRelations.tsx
+++ b/src/components/terms/TermRelations.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement } from "react";
-import { Box, styled, Typography } from "@mui/material";
+import { Box, styled } from "@mui/material";
 import { TermInterface } from "../../api/data/terms";
 import { CurrentRelationTerm } from "./RelationItem";
 import { calculateConnector } from "./Relations";
-import RelationConnector, { TLine } from "./RelationConnector";
 import useIsMobile from "../../hooks/useIsMobile";
 import TermRelationsMobile from "./TermRelationsMobile";
 
@@ -61,9 +60,14 @@ const TermRelations: React.FC<RelationsItemProps> = ({
       </Box>
     );
   } else {
-    return <TermRelationsMobile currentTerm={currentTerm} domains={domains} ranges={ranges}/>
+    return (
+      <TermRelationsMobile
+        currentTerm={currentTerm}
+        domains={domains}
+        ranges={ranges}
+      />
+    );
   }
 };
-
 
 export default TermRelations;

--- a/src/components/terms/TermRelationsMobile.tsx
+++ b/src/components/terms/TermRelationsMobile.tsx
@@ -24,17 +24,27 @@ const TermRelationsMobile: React.FC<RelationsItemProps> = ({
     return <RelationItemWrapper key={item.key} {...props} />;
   });
 
-  const rangeArr = [...ranges, currEl];
+  const rangeArr = [...ranges];
   const rangeRows = rangeArr.map((item, index) => {
     const position = getRelationPosition(index, rangeArr.length);
     const props = getRangeConnectors(position, item);
     return <RelationItemWrapper key={item.key} {...props} />;
   });
 
+  const wrappedCurrent = (
+      currElement: ReactElement
+  ): RelationItemWrapperProps => {
+    return {
+      row1M: currElement,
+      row1L: <RelationConnector type={"m_lline"} />,
+    };
+  };
+
   return (
     <Box>
       {domains.length !== 0 && domainRows}
       {ranges.length !== 0 && rangeRows}
+      {ranges.length !==0 && <RelationItemWrapper key={currEl.key} {...wrappedCurrent(currEl)}/>}
     </Box>
   );
 };
@@ -54,7 +64,7 @@ const getDomainConnectors = (
       row2R: <RelationConnector type={"m_lline90"} />,
     };
   }
-  if (position === "MIDDLE" || position === "PENULTIMATE") {
+  if (position === "MIDDLE") {
     return {
       row1L: <RelationConnector type={"m_hline"} />,
       row1M: currElement,
@@ -86,8 +96,9 @@ const getRangeConnectors = (
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_lline180"} />,
-      row2R: <RelationConnector type={"m_f_vertical"} />,
+      row2R: <RelationConnector type={"m_f_lline"} />,
       row2M: <RelationConnector type={"m_horizontal"} />,
+      row2L: <RelationConnector type={"m_lline270"}/>
     };
   }
   if (position === "MIDDLE") {
@@ -97,19 +108,13 @@ const getRangeConnectors = (
       row2R: <RelationConnector type={"m_f_vertical"} />,
     };
   }
-  if (position === "PENULTIMATE") {
-    return {
-      row1R: <RelationConnector type={"m_f_hline"} />,
-      row1M: currElement,
-      row2L: <RelationConnector type={"m_lline270"} />,
-      row2M: <RelationConnector type={"m_horizontal"} />,
-      row2R: <RelationConnector type={"m_f_lline"} />,
-    };
-  }
   if (position === "LAST") {
     return {
-      row1L: <RelationConnector type={"m_lline"} />,
       row1M: currElement,
+      row1R: <RelationConnector type={"m_f_hline"} />,
+      row2R: <RelationConnector type={"m_f_lline"} />,
+      row2M: <RelationConnector type={"m_horizontal"} />,
+      row2L: <RelationConnector type={"m_lline270"}/>
     };
   }
 

--- a/src/components/terms/TermRelationsMobile.tsx
+++ b/src/components/terms/TermRelationsMobile.tsx
@@ -1,0 +1,167 @@
+import React, { ReactElement } from "react";
+import { RelationsItemProps } from "./TermRelations";
+import { Box, BoxProps, Typography } from "@mui/material";
+import { CurrentRelationTerm } from "./RelationItem";
+import RelationConnector from "./RelationConnector";
+import { calculateConnector } from "./Relations";
+
+const TermRelationsMobile: React.FC<RelationsItemProps> = ({
+  domains,
+  currentTerm,
+  ranges,
+}) => {
+  const currEl = (
+    <CurrentRelationTerm key={currentTerm.$id} data={currentTerm} />
+  );
+
+  const domainArr = [currEl, ...domains];
+
+  const domainRows = domainArr.map((item, index) => {
+    const position = getRelationPosition(index, domainArr.length);
+    const props = getDomainConnectors(position, item);
+    return <RelationItemWrapper key={item.key} {...props} />;
+  });
+
+  const rangeArr = [currEl, ...ranges];
+  const rangeRows = rangeArr.map((item, index) => {
+    const position = getRelationPosition(index, rangeArr.length);
+    const props = getRangeConnectors(position, item);
+    return <RelationItemWrapper key={item.key} {...props} />;
+  });
+
+  return (
+    <Box>
+      {domains.length !== 0 && domainRows}
+      {ranges.length !== 0 && rangeRows}
+    </Box>
+  );
+};
+
+interface RelationItemWrapperProps {
+  row1L?: ReactElement;
+  row1M?: ReactElement;
+  row1R?: ReactElement;
+  row2L?: ReactElement;
+  row2M?: ReactElement;
+  row2R?: ReactElement;
+  boxProps?: BoxProps;
+}
+
+const RelationItemWrapper: React.FC<RelationItemWrapperProps> = ({
+  row1L,
+  row1M,
+  row1R,
+  row2L,
+  row2M,
+  row2R,
+  boxProps,
+}) => {
+  return (
+    <Box display="flex" width="100%" flexDirection="column" {...boxProps}>
+      {/**Top row**/}
+      <Box flex={1} display={"flex"}>
+        <Box flex={1} maxWidth={16}>
+          {row1L}
+        </Box>
+        <Box
+          flex={10}
+          display={"flex"}
+          justifyContent={"center"}
+          alignItems={"center"}
+        >
+          {row1M}
+        </Box>
+        <Box flex={1} maxWidth={16}>
+          {row1R}
+        </Box>
+      </Box>
+
+      {/**Bottom row**/}
+      <Box flex={1} display={"flex"} minHeight={16}>
+        <Box flex={1} maxWidth={16}>
+          {row2L}
+        </Box>
+        <Box flex={10}>{row2M}</Box>
+        <Box flex={1} maxWidth={16}>
+          {row2R}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const getRelationPosition = (index: number, size: number) => {
+  if (size === 1) {
+    return "ONLY_ONE";
+  } else if (size > 1 && index === 0) {
+    return "FIRST";
+  } else if (size > 1 && index + 1 !== size) {
+    return "MIDDLE";
+  } else if (size > 1 && index + 1 === size) {
+    return "LAST";
+  }
+  return "UNKNOWN";
+};
+
+//Gets the appropriate connectors for domain relations
+const getDomainConnectors = (
+  position: string,
+  currElement: ReactElement
+): RelationItemWrapperProps => {
+  if (position === "FIRST" || position === "ONLY_ONE") {
+    return {
+      row1M: currElement,
+      row1R: <RelationConnector type={"m_lline180"} />,
+      row2L: <RelationConnector type={"m_lline270"} />,
+      row2M: <RelationConnector type={"m_horizontal"} />,
+      row2R: <RelationConnector type={"m_lline90"} />,
+    };
+  }
+  if (position === "MIDDLE") {
+    return {
+      row1L: <RelationConnector type={"m_hline"} />,
+      row1M: currElement,
+      row2L: <RelationConnector type={"m_vertical"} />,
+    };
+  }
+  if (position === "LAST") {
+    return {
+      row1L: <RelationConnector type={"m_lline"} />,
+      row1M: currElement,
+    };
+  }
+
+  return {};
+};
+//Gets the appropriate connectors for range relations
+const getRangeConnectors = (
+  position: string,
+  currElement: ReactElement
+): RelationItemWrapperProps => {
+  if (position === "FIRST" || position === "ONLY_ONE") {
+    return {
+      row1L: <RelationConnector type={"m_f_lline180"} />,
+      row1M: currElement,
+      row2L: <RelationConnector type={"m_f_lline90"} />,
+      row2M: <RelationConnector type={"m_horizontal"} />,
+      row2R: <RelationConnector type={"m_lline180"} />,
+    };
+  }
+  if (position === "MIDDLE") {
+    return {
+      row1R: <RelationConnector type={"m_f_hline"} />,
+      row1M: currElement,
+      row2R: <RelationConnector type={"m_f_vertical"} />,
+    };
+  }
+  if (position === "LAST") {
+    return {
+      row1M: currElement,
+      row1R: <RelationConnector type={"m_f_lline"} />,
+    };
+  }
+
+  return {};
+};
+
+export default TermRelationsMobile;

--- a/src/components/terms/TermRelationsMobile.tsx
+++ b/src/components/terms/TermRelationsMobile.tsx
@@ -1,9 +1,12 @@
 import React, { ReactElement } from "react";
 import { RelationsItemProps } from "./TermRelations";
-import { Box, BoxProps, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 import { CurrentRelationTerm } from "./RelationItem";
 import RelationConnector from "./RelationConnector";
-import { calculateConnector } from "./Relations";
+import RelationItemWrapper, {
+  RelationItemWrapperProps,
+} from "./RelationItemWrapperMobile";
+import { getRelationPosition } from "../../utils/TermUtils";
 
 const TermRelationsMobile: React.FC<RelationsItemProps> = ({
   domains,
@@ -15,14 +18,13 @@ const TermRelationsMobile: React.FC<RelationsItemProps> = ({
   );
 
   const domainArr = [currEl, ...domains];
-
   const domainRows = domainArr.map((item, index) => {
     const position = getRelationPosition(index, domainArr.length);
     const props = getDomainConnectors(position, item);
     return <RelationItemWrapper key={item.key} {...props} />;
   });
 
-  const rangeArr = [currEl, ...ranges];
+  const rangeArr = [...ranges, currEl];
   const rangeRows = rangeArr.map((item, index) => {
     const position = getRelationPosition(index, rangeArr.length);
     const props = getRangeConnectors(position, item);
@@ -37,77 +39,12 @@ const TermRelationsMobile: React.FC<RelationsItemProps> = ({
   );
 };
 
-interface RelationItemWrapperProps {
-  row1L?: ReactElement;
-  row1M?: ReactElement;
-  row1R?: ReactElement;
-  row2L?: ReactElement;
-  row2M?: ReactElement;
-  row2R?: ReactElement;
-  boxProps?: BoxProps;
-}
-
-const RelationItemWrapper: React.FC<RelationItemWrapperProps> = ({
-  row1L,
-  row1M,
-  row1R,
-  row2L,
-  row2M,
-  row2R,
-  boxProps,
-}) => {
-  return (
-    <Box display="flex" width="100%" flexDirection="column" {...boxProps}>
-      {/**Top row**/}
-      <Box flex={1} display={"flex"}>
-        <Box flex={1} maxWidth={16}>
-          {row1L}
-        </Box>
-        <Box
-          flex={10}
-          display={"flex"}
-          justifyContent={"center"}
-          alignItems={"center"}
-        >
-          {row1M}
-        </Box>
-        <Box flex={1} maxWidth={16}>
-          {row1R}
-        </Box>
-      </Box>
-
-      {/**Bottom row**/}
-      <Box flex={1} display={"flex"} minHeight={16}>
-        <Box flex={1} maxWidth={16}>
-          {row2L}
-        </Box>
-        <Box flex={10}>{row2M}</Box>
-        <Box flex={1} maxWidth={16}>
-          {row2R}
-        </Box>
-      </Box>
-    </Box>
-  );
-};
-
-const getRelationPosition = (index: number, size: number) => {
-  if (size === 1) {
-    return "ONLY_ONE";
-  } else if (size > 1 && index === 0) {
-    return "FIRST";
-  } else if (size > 1 && index + 1 !== size) {
-    return "MIDDLE";
-  } else if (size > 1 && index + 1 === size) {
-    return "LAST";
-  }
-  return "UNKNOWN";
-};
-
 //Gets the appropriate connectors for domain relations
 const getDomainConnectors = (
   position: string,
   currElement: ReactElement
 ): RelationItemWrapperProps => {
+  //debugger;
   if (position === "FIRST" || position === "ONLY_ONE") {
     return {
       row1M: currElement,
@@ -117,7 +54,7 @@ const getDomainConnectors = (
       row2R: <RelationConnector type={"m_lline90"} />,
     };
   }
-  if (position === "MIDDLE") {
+  if (position === "MIDDLE" || position === "PENULTIMATE") {
     return {
       row1L: <RelationConnector type={"m_hline"} />,
       row1M: currElement,
@@ -138,13 +75,19 @@ const getRangeConnectors = (
   position: string,
   currElement: ReactElement
 ): RelationItemWrapperProps => {
-  if (position === "FIRST" || position === "ONLY_ONE") {
+  if (position === "FIRST") {
     return {
-      row1L: <RelationConnector type={"m_f_lline180"} />,
       row1M: currElement,
-      row2L: <RelationConnector type={"m_f_lline90"} />,
+      row1R: <RelationConnector type={"m_lline180"} />,
+      row2R: <RelationConnector type={"m_f_vertical"} />,
+    };
+  }
+  if (position === "ONLY_ONE") {
+    return {
+      row1M: currElement,
+      row1R: <RelationConnector type={"m_lline180"} />,
+      row2R: <RelationConnector type={"m_f_vertical"} />,
       row2M: <RelationConnector type={"m_horizontal"} />,
-      row2R: <RelationConnector type={"m_lline180"} />,
     };
   }
   if (position === "MIDDLE") {
@@ -154,10 +97,19 @@ const getRangeConnectors = (
       row2R: <RelationConnector type={"m_f_vertical"} />,
     };
   }
+  if (position === "PENULTIMATE") {
+    return {
+      row1R: <RelationConnector type={"m_f_hline"} />,
+      row1M: currElement,
+      row2L: <RelationConnector type={"m_lline270"} />,
+      row2M: <RelationConnector type={"m_horizontal"} />,
+      row2R: <RelationConnector type={"m_f_lline"} />,
+    };
+  }
   if (position === "LAST") {
     return {
+      row1L: <RelationConnector type={"m_lline"} />,
       row1M: currElement,
-      row1R: <RelationConnector type={"m_f_lline"} />,
     };
   }
 

--- a/src/components/terms/TermRelationsMobile.tsx
+++ b/src/components/terms/TermRelationsMobile.tsx
@@ -6,7 +6,7 @@ import RelationConnector from "./RelationConnector";
 import RelationItemWrapper, {
   RelationItemWrapperProps,
 } from "./RelationItemWrapperMobile";
-import { getRelationPosition } from "../../utils/TermUtils";
+import { getRelationPosition, RelationPosition } from "../../utils/TermUtils";
 
 const TermRelationsMobile: React.FC<RelationsItemProps> = ({
   domains,
@@ -31,31 +31,36 @@ const TermRelationsMobile: React.FC<RelationsItemProps> = ({
     return <RelationItemWrapper key={item.key} {...props} />;
   });
 
-  const wrappedCurrent = (
-      currElement: ReactElement
-  ): RelationItemWrapperProps => {
-    return {
-      row1M: currElement,
-      row1L: <RelationConnector type={"m_lline"} />,
-    };
-  };
-
   return (
     <Box>
       {domains.length !== 0 && domainRows}
       {ranges.length !== 0 && rangeRows}
-      {ranges.length !==0 && <RelationItemWrapper key={currEl.key} {...wrappedCurrent(currEl)}/>}
+      {ranges.length !== 0 && (
+        <RelationItemWrapper key={currEl.key} {...wrappedCurrent(currEl)} />
+      )}
     </Box>
   );
 };
 
-//Gets the appropriate connectors for domain relations
-const getDomainConnectors = (
-  position: string,
+//Code belows addresses all possible connectors for terms regarding their position in the visualisation
+
+const wrappedCurrent = (
   currElement: ReactElement
 ): RelationItemWrapperProps => {
-  //debugger;
-  if (position === "FIRST" || position === "ONLY_ONE") {
+  return {
+    row1M: currElement,
+    row1L: <RelationConnector type={"m_lline"} />,
+  };
+};
+
+const getDomainConnectors = (
+  position: RelationPosition,
+  currElement: ReactElement
+): RelationItemWrapperProps => {
+  if (
+    position === RelationPosition.FIRST ||
+    position === RelationPosition.ONLY_ONE
+  ) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_lline180"} />,
@@ -64,61 +69,61 @@ const getDomainConnectors = (
       row2R: <RelationConnector type={"m_lline90"} />,
     };
   }
-  if (position === "MIDDLE") {
+  if (position === RelationPosition.MIDDLE) {
     return {
       row1L: <RelationConnector type={"m_hline"} />,
       row1M: currElement,
       row2L: <RelationConnector type={"m_vertical"} />,
     };
   }
-  if (position === "LAST") {
+  if (position === RelationPosition.LAST) {
     return {
       row1L: <RelationConnector type={"m_lline"} />,
       row1M: currElement,
     };
   }
 
-  return {};
+  return { row1M: currElement };
 };
-//Gets the appropriate connectors for range relations
+
 const getRangeConnectors = (
-  position: string,
+  position: RelationPosition,
   currElement: ReactElement
 ): RelationItemWrapperProps => {
-  if (position === "FIRST") {
+  if (position === RelationPosition.FIRST) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_lline180"} />,
       row2R: <RelationConnector type={"m_f_vertical"} />,
     };
   }
-  if (position === "ONLY_ONE") {
+  if (position === RelationPosition.ONLY_ONE) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_lline180"} />,
       row2R: <RelationConnector type={"m_f_lline"} />,
       row2M: <RelationConnector type={"m_horizontal"} />,
-      row2L: <RelationConnector type={"m_lline270"}/>
+      row2L: <RelationConnector type={"m_lline270"} />,
     };
   }
-  if (position === "MIDDLE") {
+  if (position === RelationPosition.MIDDLE) {
     return {
       row1R: <RelationConnector type={"m_f_hline"} />,
       row1M: currElement,
       row2R: <RelationConnector type={"m_f_vertical"} />,
     };
   }
-  if (position === "LAST") {
+  if (position === RelationPosition.LAST) {
     return {
       row1M: currElement,
       row1R: <RelationConnector type={"m_f_hline"} />,
       row2R: <RelationConnector type={"m_f_lline"} />,
       row2M: <RelationConnector type={"m_horizontal"} />,
-      row2L: <RelationConnector type={"m_lline270"}/>
+      row2L: <RelationConnector type={"m_lline270"} />,
     };
   }
 
-  return {};
+  return { row1M: currElement };
 };
 
 export default TermRelationsMobile;

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,21 +1,21 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 
 const getIsMobile = () => window.innerWidth <= 768;
 
 export default function useIsMobile() {
-    const [isMobile, setIsMobile] = useState(getIsMobile());
+  const [isMobile, setIsMobile] = useState(getIsMobile());
 
-    useEffect(() => {
-        const onResize = () => {
-            setIsMobile(getIsMobile());
-        }
+  useEffect(() => {
+    const onResize = () => {
+      setIsMobile(getIsMobile());
+    };
 
-        window.addEventListener("resize", onResize);
+    window.addEventListener("resize", onResize);
 
-        return () => {
-            window.removeEventListener("resize", onResize);
-        }
-    }, []);
+    return () => {
+      window.removeEventListener("resize", onResize);
+    };
+  }, []);
 
-    return isMobile;
+  return isMobile;
 }

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+import {useEffect, useState} from "react";
+
+const getIsMobile = () => window.innerWidth <= 768;
+
+export default function useIsMobile() {
+    const [isMobile, setIsMobile] = useState(getIsMobile());
+
+    useEffect(() => {
+        const onResize = () => {
+            setIsMobile(getIsMobile());
+        }
+
+        window.addEventListener("resize", onResize);
+
+        return () => {
+            window.removeEventListener("resize", onResize);
+        }
+    }, []);
+
+    return isMobile;
+}

--- a/src/utils/TermUtils.ts
+++ b/src/utils/TermUtils.ts
@@ -30,3 +30,18 @@ export const generateStyledSnippet = (
     ? `<i> - ${snippetText}</i>`
     : `<i> - ${snippetText}</i>&hellip;`;
 };
+
+export const getRelationPosition = (index: number, size: number) => {
+  if (size === 1) {
+    return "ONLY_ONE";
+  } else if (size > 1 && index === 0) {
+    return "FIRST";
+  } else if (size > 1 && index + 1 === size - 1) {
+    return "PENULTIMATE";
+  } else if (size > 1 && index + 1 !== size) {
+    return "MIDDLE";
+  } else if (size > 1 && index + 1 === size) {
+    return "LAST";
+  }
+  return "UNKNOWN";
+};

--- a/src/utils/TermUtils.ts
+++ b/src/utils/TermUtils.ts
@@ -31,15 +31,26 @@ export const generateStyledSnippet = (
     : `<i> - ${snippetText}</i>&hellip;`;
 };
 
-export const getRelationPosition = (index: number, size: number) => {
+export enum RelationPosition {
+  ONLY_ONE,
+  FIRST,
+  MIDDLE,
+  LAST,
+  UNKNOWN,
+}
+
+export const getRelationPosition = (
+  index: number,
+  size: number
+): RelationPosition => {
   if (size === 1) {
-    return "ONLY_ONE";
+    return RelationPosition.ONLY_ONE;
   } else if (size > 1 && index === 0) {
-    return "FIRST";
+    return RelationPosition.FIRST;
   } else if (size > 1 && index + 1 !== size) {
-    return "MIDDLE";
+    return RelationPosition.MIDDLE;
   } else if (size > 1 && index + 1 === size) {
-    return "LAST";
+    return RelationPosition.LAST;
   }
-  return "UNKNOWN";
+  return RelationPosition.UNKNOWN;
 };

--- a/src/utils/TermUtils.ts
+++ b/src/utils/TermUtils.ts
@@ -36,8 +36,6 @@ export const getRelationPosition = (index: number, size: number) => {
     return "ONLY_ONE";
   } else if (size > 1 && index === 0) {
     return "FIRST";
-  } else if (size > 1 && index + 1 === size - 1) {
-    return "PENULTIMATE";
   } else if (size > 1 && index + 1 !== size) {
     return "MIDDLE";
   } else if (size > 1 && index + 1 === size) {


### PR DESCRIPTION
Relations amongst the terms are now viewable on mobile devices. Solution using only pure CSS wasn't feasable due to the changed structure of number of elements and their position, I hope this has better readability. Performance shouldn't be an issue.

Resolves: #113 