### PR TITLE
[#120] Clickable definition sources

### DIFF
--- a/src/components/detail_common/DefinitionWrapper.tsx
+++ b/src/components/detail_common/DefinitionWrapper.tsx
@@ -4,9 +4,11 @@ import {
   BoxProps,
   Container,
   Grid,
+  Link,
   styled,
   Typography,
 } from "@mui/material";
+import { isValidHttpUrl } from "../../utils/TermUtils";
 
 interface DefinitionWrapperProps {
   definition?: string;
@@ -52,16 +54,7 @@ const DefinitionWrapper: React.FC<DefinitionWrapperProps & BoxProps> = (
               <Box mb={props.source ? 2 : 0}>
                 <Typography variant="h6">{props.definition}</Typography>
               </Box>
-              {props.source && (
-                <Box fontStyle="italic" color="text.disabled">
-                  <Typography
-                    variant="body1"
-                    style={{ wordWrap: "break-word" }}
-                  >
-                    {props.source}
-                  </Typography>
-                </Box>
-              )}
+              <DefinitionSource definitionSource={props.source} />
             </Box>
           </Grid>
           <IllustrationWrapper item sm={2}>
@@ -70,6 +63,35 @@ const DefinitionWrapper: React.FC<DefinitionWrapperProps & BoxProps> = (
         </Grid>
       </Box>
     </Wrapper>
+  );
+};
+
+interface DefinitionSourceProps {
+  definitionSource?: string;
+}
+
+const DefinitionSource: React.FC<DefinitionSourceProps> = ({
+  definitionSource,
+}) => {
+  if (!definitionSource) return null;
+  const content = isValidHttpUrl(definitionSource) ? (
+    <Link
+      target="_blank"
+      rel="noopener"
+      href={definitionSource}
+      color="text.disabled"
+    >
+      {definitionSource}
+    </Link>
+  ) : (
+    <Typography variant="body1" color="text.disabled">
+      {definitionSource}
+    </Typography>
+  );
+  return (
+    <Box fontStyle="italic" style={{ wordWrap: "break-word" }}>
+      {content}
+    </Box>
   );
 };
 

--- a/src/utils/TermUtils.ts
+++ b/src/utils/TermUtils.ts
@@ -54,3 +54,15 @@ export const getRelationPosition = (
   }
   return RelationPosition.UNKNOWN;
 };
+
+export const isValidHttpUrl = (definition: string): boolean => {
+  let url;
+
+  try {
+    url = new URL(definition);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:";
+};


### PR DESCRIPTION
When definition source is a valid link, it can be clicked

Resolves: #120 